### PR TITLE
add Tformer and LeNet baselines

### DIFF
--- a/baselines/Train.py
+++ b/baselines/Train.py
@@ -89,7 +89,10 @@ def test(epoch, testloader, model, criterion, args, device):
             for i in range(len(dates)):
                 date = dates[i]
                 try:
-                    efi_tensor = torch.as_tensor(ds_efi.sel(time=date).to_numpy()).to(device)
+                    if (args.model == 'Tformer') or (args.model == 'LeNet'):
+                        efi_tensor = torch.reshape(torch.as_tensor(ds_efi.sel(time=date).to_numpy()).to(device), (361,720))
+                    else:
+                        efi_tensor = torch.as_tensor(ds_efi.sel(time=date).to_numpy()).to(device)
                     loss_efi = crps_efi(mu[i,...], sigma[i,...], targets[i,...], efi_tensor)
                     test_loss_efi.append(loss_efi.item())
                 except KeyError:

--- a/baselines/Train.py
+++ b/baselines/Train.py
@@ -75,10 +75,7 @@ def test(epoch, testloader, model, criterion, args, device):
             for i in range(len(dates)):
                 date = dates[i]
                 try:
-                    if (args.model == 'Tformer') or (args.model == 'LeNet'):
-                        efi_tensor = torch.reshape(torch.as_tensor(ds_efi.sel(time=date).to_numpy()).to(device), (361,720))
-                    else:
-                        efi_tensor = torch.as_tensor(ds_efi.sel(time=date).to_numpy()).to(device)
+                    efi_tensor = torch.as_tensor(ds_efi.sel(time=date).to_numpy()).to(device)
                     loss_efi = crps_efi(mu[i,...], sigma[i,...], targets[i,...], efi_tensor)
                     test_loss_efi.append(loss_efi.item())
                 except KeyError:

--- a/baselines/loader.py
+++ b/baselines/loader.py
@@ -335,7 +335,6 @@ class ENS10FullEnsembleDataset(Dataset):
             ds_ens10 = ds_ens10.stack(space=["latitude","longitude"])
             timestr = ds_ens10.valid_time.dt.strftime("%Y-%m-%d").item()
             ds_era5 = self.ds_era5.sel(time=timestr).compute()
-            #variable = #self.target_var
 
             inputs = torch.zeros((len(self.variables), self.num_ensemble, 361, 720))
             for k in range(len(self.variables)):
@@ -348,16 +347,8 @@ class ENS10FullEnsembleDataset(Dataset):
                 if (variable == self.target_var) or (variable == 'z' and self.target_var == 'z500') or (variable == 't' and self.target_var == 't850'):
                     values_tar = torch.reshape(torch.as_tensor(ds_ens10[variable].to_numpy()[:self.num_ensemble,:]), (1,self.num_ensemble,361,720))
             inputs = inputs.movedim(0,1)
-            #values_orig = torch.as_tensor(ds_ens10[variable].to_numpy()[:self.num_ensemble,:])
-            #if self.normalized:
-            #    minval, maxval = self.value_range[variable]
-            #    values = (values_orig - minval) / (maxval - minval)
-            #else:
-            #    values = values_orig
-            #inputs = values#.transpose(0, 1)
-            targets = torch.as_tensor(ds_era5.to_numpy())#.ravel()
+            targets = torch.as_tensor(ds_era5.to_numpy())
             scale_std, scale_mean = torch.std_mean(values_tar, dim=1, unbiased=False)
-            #inputs = torch.div(torch.sub(inputs, scale_mean), scale_std)
             if self.return_time:
                 return timestr, inputs, targets, scale_mean, scale_std
             else:

--- a/baselines/loader.py
+++ b/baselines/loader.py
@@ -147,9 +147,9 @@ class ENS10GridWindowDataset(Dataset):
                 inputs[-1, :] = lat.cos()*lon.cos()
             #inputs = inputs.transpose(0, 1) # shape: (#sample, #var+2)
             inputs = torch.reshape(inputs, (inputs.shape[0], 361, 720))
-            targets = torch.reshape(torch.as_tensor(self.ds_era5.isel(time=tind).stack(space=["lat","lon"]).compute().to_numpy()), (1, 361, 720))
-            scale_mean = torch.reshape(torch.as_tensor(self.ds_scale_mean.isel(time=tind).stack(space=["lat","lon"]).compute().to_numpy()), (1, 361, 720))
-            scale_std = torch.reshape(torch.as_tensor(self.ds_scale_std.isel(time=tind).stack(space=["lat","lon"]).compute().to_numpy()), (1, 361, 720))
+            targets = torch.as_tensor(self.ds_era5.isel(time=tind).stack(space=["lat","lon"]).compute().to_numpy())
+            scale_mean = torch.as_tensor(self.ds_scale_mean.isel(time=tind).stack(space=["lat","lon"]).compute().to_numpy())
+            scale_std = torch.as_tensor(self.ds_scale_std.isel(time=tind).stack(space=["lat","lon"]).compute().to_numpy())
             if self.return_time:
                 return self.ds_mean.time[tind].dt.strftime("%Y-%m-%d").item(), inputs, targets, scale_mean, scale_std
             else:
@@ -345,9 +345,9 @@ class ENS10FullEnsembleDataset(Dataset):
                     values = (values - minval) / (maxval - minval)
                 inputs[k, :] = values
                 if (variable == self.target_var) or (variable == 'z' and self.target_var == 'z500') or (variable == 't' and self.target_var == 't850'):
-                    values_tar = torch.reshape(torch.as_tensor(ds_ens10[variable].to_numpy()[:self.num_ensemble,:]), (1,self.num_ensemble,361,720))
+                    values_tar = torch.reshape(torch.as_tensor(ds_ens10[variable].to_numpy()[:self.num_ensemble,:]), (1,self.num_ensemble,361*720))
             inputs = inputs.movedim(0,1)
-            targets = torch.as_tensor(ds_era5.to_numpy())
+            targets = torch.reshape(torch.as_tensor(ds_era5.to_numpy()),(1,361*720))
             scale_std, scale_mean = torch.std_mean(values_tar, dim=1, unbiased=False)
             if self.return_time:
                 return timestr, inputs, targets, scale_mean, scale_std

--- a/baselines/loader.py
+++ b/baselines/loader.py
@@ -73,6 +73,88 @@ class ENS10GridDataset(Dataset):
 
 
 
+class ENS10GridWindowDataset(Dataset):
+    """
+    data_path: the path of folder storing the preprocessed ENS10 & ERA5 data
+    nbatch: number of batches (assuming batch size = 1)
+    nsample: number of samples per batch
+    target_var: one of "t850", "z500", "t2m" indicating target variable to predict
+    dataset_type: one of "train", "test" indicating generating train (1998-2015) or test (2016-2017) dataset
+    normalized: whether to use normalized data
+    """
+    def __init__(self, data_path, nsample, target_var, dataset_type = "train", normalized=True, location_embedding=True, return_time=False):
+        suffix = ""
+        if normalized:
+            suffix = "_normalized"
+        if dataset_type == "train":
+            time_range = slice("1998-01-01", "2015-12-31")
+        elif dataset_type == "test":
+            time_range = slice("2016-01-01", "2017-12-31")
+        if target_var in ["t850", "z500"]:
+            ds_mean = xr.open_dataset(f"{data_path}/ENS10_pl_mean{suffix}.nc", chunks={"time": 1}, engine="h5netcdf").sel(time=time_range)
+            ds_std = xr.open_dataset(f"{data_path}/ENS10_pl_std{suffix}.nc", chunks={"time": 1}, engine="h5netcdf").sel(time=time_range)
+            self.ds_scale_mean = xr.open_dataset(f"{data_path}/ENS10_pl_mean.nc", chunks={"time": 1}, engine="h5netcdf").sel(time=time_range)
+            self.ds_scale_std = xr.open_dataset(f"{data_path}/ENS10_pl_std.nc", chunks={"time": 1}, engine="h5netcdf").sel(time=time_range)
+            self.variables = ["Z", "T", "Q", "W", "D", "U", "V"]
+            if target_var == "t850":
+                self.ds_mean = ds_mean.sel(plev=85000)
+                self.ds_std = ds_std.sel(plev=85000)
+                self.ds_era5 = xr.open_dataset(f"{data_path}/ERA5_t850.nc", chunks={"time": 1}, engine="h5netcdf").sel(time=time_range).isel(plev=0).T
+                self.ds_scale_mean = self.ds_scale_mean.sel(plev=85000).T
+                self.ds_scale_std = self.ds_scale_std.sel(plev=85000).T
+            elif target_var == "z500":
+                self.ds_mean = ds_mean.sel(plev=50000)
+                self.ds_std = ds_std.sel(plev=50000)
+                self.ds_era5 = xr.open_dataset(f"{data_path}/ERA5_z500.nc", chunks={"time": 1}, engine="h5netcdf").sel(time=time_range).isel(plev=0).Z
+                self.ds_scale_mean = self.ds_scale_mean.sel(plev=50000).Z
+                self.ds_scale_std = self.ds_scale_std.sel(plev=50000).Z
+                
+        elif target_var in ["t2m"]:
+            self.ds_mean = xr.open_dataset(f"{data_path}/ENS10_sfc_mean{suffix}.nc", chunks={"time": 1}, engine="h5netcdf").sel(time=time_range)
+            self.ds_std = xr.open_dataset(f"{data_path}/ENS10_sfc_std{suffix}.nc", chunks={"time": 1}, engine="h5netcdf").sel(time=time_range)
+            self.ds_era5 = xr.open_dataset(f"{data_path}/ERA5_sfc_t2m.nc", chunks={"time": 1}, engine="h5netcdf").sel(time=time_range).T2M
+            self.variables = ['SSTK', 'TCW', 'TCWV', 'CP', 'MSL', 'TCC', 'U10M', 'V10M', 'T2M', 'TP', 'SKT']
+            self.ds_scale_mean = xr.open_dataset(f"{data_path}/ENS10_sfc_mean.nc", chunks={"time": 1}, engine="h5netcdf").sel(time=time_range).T2M
+            self.ds_scale_std = xr.open_dataset(f"{data_path}/ENS10_sfc_std.nc", chunks={"time": 1}, engine="h5netcdf").sel(time=time_range).T2M
+        self.nbatch = self.ds_mean.time.shape[0]
+        self.nsample = nsample
+        self.shape = [self.ds_mean[i].shape[0] for i in ["time", "lat", "lon"]]
+        self.location_embedding = location_embedding
+        self.return_time = return_time
+
+    def __len__(self):
+        return self.nbatch
+
+    def __getitem__(self, idx):
+        if isinstance(idx, int):
+            tind = idx
+            mean_sampled = self.ds_mean.isel(time=tind).stack(space=["lat","lon"]).compute()
+            std_sampled = self.ds_std.isel(time=tind).stack(space=["lat","lon"]).compute()
+            input_len = len(self.variables)*2
+            if self.location_embedding:
+                input_len = input_len + 3
+            inputs = torch.zeros((input_len, mean_sampled.lat.shape[0]))
+            for k in range(len(self.variables)):
+                variable = self.variables[k]
+                inputs[2*k, :] = torch.as_tensor(mean_sampled[variable].to_numpy())
+                inputs[2*k+1, :] = torch.as_tensor(std_sampled[variable].to_numpy())
+            if self.location_embedding:
+                lat = torch.as_tensor(mean_sampled.lat.to_numpy()/180*np.pi)
+                lon = torch.as_tensor(mean_sampled.lon.to_numpy()/180*np.pi)
+                #inputs[-4, :] = lat.cos()
+                inputs[-3, :] = lat.sin()
+                inputs[-2, :] = lat.cos()*lon.sin()
+                inputs[-1, :] = lat.cos()*lon.cos()
+            #inputs = inputs.transpose(0, 1) # shape: (#sample, #var+2)
+            inputs = torch.reshape(inputs, (inputs.shape[0], 361, 720))
+            targets = torch.reshape(torch.as_tensor(self.ds_era5.isel(time=tind).stack(space=["lat","lon"]).compute().to_numpy()), (1, 361, 720))
+            scale_mean = torch.reshape(torch.as_tensor(self.ds_scale_mean.isel(time=tind).stack(space=["lat","lon"]).compute().to_numpy()), (1, 361, 720))
+            scale_std = torch.reshape(torch.as_tensor(self.ds_scale_std.isel(time=tind).stack(space=["lat","lon"]).compute().to_numpy()), (1, 361, 720))
+            if self.return_time:
+                return self.ds_mean.time[tind].dt.strftime("%Y-%m-%d").item(), inputs, targets, scale_mean, scale_std
+            else:
+                return inputs, targets, scale_mean, scale_std
+
 class ENS10PointDataset(Dataset):
     """
     data_path: the path of folder storing the preprocessed ENS10 & ERA5 data
@@ -211,6 +293,76 @@ class ENS10EnsembleDataset(Dataset):
             else:
                 return inputs, targets, scale_mean, scale_std
 
+
+class ENS10FullEnsembleDataset(Dataset):
+    def __init__(self, data_path, nsample, target_var, num_ensemble=10, dataset_type="train", normalized=True, return_time=False):
+        self.num_ensemble = num_ensemble
+        self.normalized = normalized
+        self.return_time = return_time
+        if dataset_type == "train":
+            time_range = ("19980101", "20151231")
+        elif dataset_type == "test":
+            time_range = ("20160101", "20171227")
+        if target_var in ["z500", "t850"]:
+            level_type = "pl"
+            era5_prefix = f"ERA5_{target_var}"
+            self.variables = ["z", "t", "q", "w", "d", "u", "v"]
+            if target_var == "z500":
+                self.level = 500
+                self.target_var = "z"
+                self.value_range = {"z": (48200, 58000), "t": (230, 269), "q": (0., 4e-3), "w": (-0.7, 1.4), "d": (-5e-5, 8e-5), "u": (-7., 27.), "v": (-7., 7.)}
+            if target_var == "t850":
+                self.level = 850
+                self.target_var = "t"
+                self.value_range = {"z": (10000, 15500), "t":(240, 299), "q": (0., 1.5e-2), "w": (-1.2, 1.8), "d": (-1.9e-4, 1.6e-4), "u": (-16., 17.5), "v": (-10., 16.)}
+        elif target_var in ["t2m"]:
+            level_type = "sfc"
+            era5_prefix = f"ERA5_sfc_{target_var}"
+            self.variables = ['sst', 'tcw', 'tcwv', 'cp', 'msl', 'tcc', 'u10', 'v10', 't2m', 'tp', 'skt']
+            self.level = 0
+            self.target_var = "t2m"
+            self.value_range = {"sst": (260., 305.), "tcw": (0., 60.), "tcwv": (0., 60.), "cp": (0., 0.04), "msl": (97000., 1.1e5), "tcc": (0., 1.0), "u10": (-13., 11.), "v10": (-10., 15.), "t2m":(218, 304), "tp": (0., 0.07), "skt": (210., 310.)}
+        prefix = f"{data_path}/ensemble/output.{level_type}."
+        self.ens10_files = [f for f in glob.glob(f"{prefix}*.grib") if (f >= f"{prefix}{time_range[0]}.grib" and f <= f"{prefix}{time_range[1]}.grib")]
+        self.ds_era5 = xr.open_dataarray(f"{data_path}/{era5_prefix}.nc", chunks={"time":1}, engine="h5netcdf")
+
+    def __len__(self):
+        return len(self.ens10_files)
+
+    def __getitem__(self, idx):
+        if isinstance(idx, int):
+            ds_ens10 = xr.load_dataset(self.ens10_files[idx], engine="cfgrib", backend_kwargs={"indexpath":"", "filter_by_keys": {'level': self.level}}).fillna(9999.0)
+            ds_ens10 = ds_ens10.stack(space=["latitude","longitude"])
+            timestr = ds_ens10.valid_time.dt.strftime("%Y-%m-%d").item()
+            ds_era5 = self.ds_era5.sel(time=timestr).compute()
+            #variable = #self.target_var
+
+            inputs = torch.zeros((len(self.variables), self.num_ensemble, 361, 720))
+            for k in range(len(self.variables)):
+                variable = self.variables[k]
+                values = torch.reshape(torch.as_tensor(ds_ens10[variable].to_numpy()[:self.num_ensemble,:]), (self.num_ensemble,361,720))
+                if self.normalized:
+                    minval, maxval = self.value_range[variable]
+                    values = (values - minval) / (maxval - minval)
+                inputs[k, :] = values
+                if (variable == self.target_var) or (variable == 'z' and self.target_var == 'z500') or (variable == 't' and self.target_var == 't850'):
+                    values_tar = torch.reshape(torch.as_tensor(ds_ens10[variable].to_numpy()[:self.num_ensemble,:]), (1,self.num_ensemble,361,720))
+            inputs = inputs.movedim(0,1)
+            #values_orig = torch.as_tensor(ds_ens10[variable].to_numpy()[:self.num_ensemble,:])
+            #if self.normalized:
+            #    minval, maxval = self.value_range[variable]
+            #    values = (values_orig - minval) / (maxval - minval)
+            #else:
+            #    values = values_orig
+            #inputs = values#.transpose(0, 1)
+            targets = torch.as_tensor(ds_era5.to_numpy())#.ravel()
+            scale_std, scale_mean = torch.std_mean(values_tar, dim=1, unbiased=False)
+            #inputs = torch.div(torch.sub(inputs, scale_mean), scale_std)
+            if self.return_time:
+                return timestr, inputs, targets, scale_mean, scale_std
+            else:
+                return inputs, targets, scale_mean, scale_std
+
 # dataloader = DataLoader(ENS10PointDataset(data_path, 1, 10, "t2m", "test"), batch_size=1, ...)
 
 
@@ -249,6 +401,30 @@ def loader_prepare(args):
                                                      nsample=361*720,
                                                      target_var=args.target_var,
                                                      dataset_type='test', num_ensemble=args.ens_num, return_time=True),
+                                args.batch_size, shuffle=False, num_workers=4, pin_memory=True, prefetch_factor=4, persistent_workers=False)
+    elif args.model == "Tformer":
+        trainloader = DataLoader(ENS10FullEnsembleDataset(data_path=args.data_path,
+                                                      nsample=361*720,
+                                                      target_var=args.target_var,
+                                                      dataset_type='train', num_ensemble=args.ens_num),
+                                 args.batch_size, shuffle=True, num_workers=8, pin_memory=True, prefetch_factor=6, persistent_workers=True)
+
+        testloader = DataLoader(ENS10FullEnsembleDataset(data_path=args.data_path,
+                                                     nsample=361*720,
+                                                     target_var=args.target_var,
+                                                     dataset_type='test', num_ensemble=args.ens_num, return_time=True),
+                                args.batch_size, shuffle=False, num_workers=4, pin_memory=True, prefetch_factor=4, persistent_workers=False)
+    elif args.model == "LeNet":
+        trainloader = DataLoader(ENS10GridWindowDataset(data_path=args.data_path,
+                                                   nsample=361*720,
+                                                   target_var=args.target_var,
+                                                   dataset_type='train', location_embedding=True),
+                                 args.batch_size, shuffle=True, num_workers=4, pin_memory=True, prefetch_factor=4, persistent_workers=True)
+
+        testloader = DataLoader(ENS10GridWindowDataset(data_path=args.data_path,
+                                                  nsample=361*720,
+                                                  target_var=args.target_var,
+                                                  dataset_type='test', location_embedding=True, return_time=True),
                                 args.batch_size, shuffle=False, num_workers=4, pin_memory=True, prefetch_factor=4, persistent_workers=False)
     else:
         pass

--- a/baselines/models/LeNet.py
+++ b/baselines/models/LeNet.py
@@ -1,0 +1,102 @@
+# Implementation of the LeNet-Style baseline (see https://www.sciencedirect.com/science/article/pii/S0022169421013512)
+# The input is a grid with 2*n channels where n is the number of variables in the pressure levels
+# The output of the network are two grids
+
+from torch import nn as nn
+import torch
+import torch.nn.functional as F
+
+BASE_FILTER = 16  # has to be divideable by 4, originally 16
+
+def batch_norm(
+    out_channels, dim=2
+):  # Does not have the same parameters as the original batch normalization used in the tensorflow 1.14 version of this project
+    if dim == 2:
+        bnr = torch.nn.BatchNorm2d(out_channels)
+    else:
+        bnr = torch.nn.BatchNorm3d(out_channels)
+    return bnr
+
+# 3x3x3 convolution module
+def Conv(in_channels, out_channels, filter_sizes=3, dim=2):
+    if dim == 2:
+        return nn.Conv2d(
+            in_channels, out_channels, filter_sizes, padding=0
+        )
+    else:
+        return nn.Conv3d(
+            in_channels, out_channels, filter_sizes, padding=(filter_sizes - 1) // 2
+        )
+
+# Activation function
+def activation(x):
+    # Simple relu
+    return F.elu(x, inplace=True)
+
+# Conv Batch Relu module
+class ConvBatchElu(nn.Module):
+    def __init__(self, in_channels, out_channels, filter_sizes=3):
+        super(ConvBatchElu, self).__init__()
+        self.conv = Conv(in_channels, out_channels, filter_sizes)
+        self.bnr = batch_norm(out_channels)
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.bnr(activation(x))
+        return x
+
+
+class LeNet(nn.Module):
+    def __init__(
+            self, in_channels=14, args=None
+    ):
+        super(LeNet, self).__init__()
+
+        self.dim = 2
+
+        self.ic = in_channels
+        oc = 2
+        self.conv1 = ConvBatchElu(self.ic, 64)
+        self.conv2 = ConvBatchElu(64, 32)
+        self.conv3 = ConvBatchElu(32, 16)
+
+        self.dense1 = nn.Linear(19, 6)
+        self.dense2 = nn.Linear(6,2)
+
+        self.pad = nn.ReplicationPad2d(3)
+        self.unfold = nn.Unfold((7,7))
+
+    def forward(self, inp):
+
+        x = inp[:,:self.ic,:,:]
+        emb = inp[:,self.ic:,:,:]
+
+        x = self.pad(x)
+        x = self.unfold(x)
+
+        x = torch.movedim(x, -2, -1)
+        x = torch.reshape(x, (x.shape[1], self.ic, 7, 7))
+
+        x = self.conv1(x)
+        x = self.conv2(x)
+        x = self.conv3(x)
+
+        x = x[:,:,0,0]
+
+        emb = torch.movedim(emb, 1, -1)
+        emb = emb.reshape((emb.shape[-3] * emb.shape[-2]),3)
+        x = torch.concat((emb, x), dim=1)
+        
+
+        x = self.dense1(x)
+        output = self.dense2(x)
+
+
+        output = torch.reshape(output, (1,361,720,2))
+        return output
+
+def LeNet_prepare(args):
+
+    if args.target_var in ['t2m']:
+        return LeNet(22, args)
+    return LeNet(14, args)

--- a/baselines/models/LeNet.py
+++ b/baselines/models/LeNet.py
@@ -92,7 +92,7 @@ class LeNet(nn.Module):
         output = self.dense2(x)
 
 
-        output = torch.reshape(output, (1,361,720,2))
+        output = torch.reshape(output, (inp.shape[0],inp.shape[-2]*inp.shape[-1],2))
         return output
 
 def LeNet_prepare(args):

--- a/baselines/models/tformer.py
+++ b/baselines/models/tformer.py
@@ -1,0 +1,316 @@
+# Code, general network architecture and network modules are from https://github.com/tobifinn/ensemble_transformer and are used with respect to the following MIT License:
+
+#The MIT License (MIT)
+#Copyright (c) 2021, Tobias Finn
+
+#Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+# System modules
+import logging
+import abc
+from typing import Tuple, Union, Dict, Any
+from abc import abstractmethod
+
+# External modules
+import pytorch_lightning as pl
+import torch
+import torch.nn
+from torch import nn as nn
+
+import torch.nn.functional as F
+from hydra.utils import instantiate
+from omegaconf import DictConfig
+from datetime import datetime
+
+import numpy as np
+import wandb
+
+
+logger = logging.getLogger(__name__)
+
+
+class transformer(nn.Module):
+    # Multilayer perceptron
+    def __init__(self, nr_channels, nr_heads, nr_variables, in_channels, args=None):
+        super(transformer, self).__init__()
+
+        # pass hyperparameters to model constructor
+        self.nr_channels = nr_channels
+        self.nr_heads = nr_heads
+        self.nr_variables = nr_variables
+        self.in_channels = in_channels
+    
+        self.embedding = Embedding(self.in_channels, self.nr_channels, 5)
+
+        self.transformers = TransformerNet(self.nr_channels[-1], self.nr_heads)
+        
+        self.output_layer = EnsConv2d(in_channels=nr_channels[-1], out_channels=1, kernel_size=1)
+
+    def forward(self, inp):
+        embedded_tensor = self.embedding(inp)
+        transformed_tensor = self.transformers(embedded_tensor)
+        output_tensor = self.output_layer(transformed_tensor).squeeze(dim=-3)
+        return output_tensor
+
+def Tformer_prepare(args):
+    if args.target_var in ['t2m']:
+        return transformer([8,8,8], 16, 11, 11)
+    return transformer([8,8,8], 16, 7, 7)
+
+# Embedding module according to paper
+class Embedding(nn.Module):
+    def __init__(self, in_channels, nr_channels, kernel_size):
+        super(Embedding, self).__init__()
+        modules = []
+        old_channels = in_channels
+        for curr_channel in nr_channels:
+            modules.append(EarthPadding((kernel_size-1)//2))
+            modules.append(EnsConv2d(old_channels, curr_channel, kernel_size=kernel_size))
+            modules.append(nn.SELU(inplace=True))
+            old_channels = curr_channel
+        self.nr_channels = nr_channels
+        self.kernel_size = kernel_size
+        self.net = torch.nn.Sequential(
+            *modules
+        )
+
+    def forward(self, x):
+        x = self.net(x)
+        return x
+
+class EarthPadding(torch.nn.Module):
+    """
+    Padding for ESMs with periodic and zero-padding in longitudinal and
+    latitudinal direction, respectively.
+    """
+    def __init__(self, pad_size: int = 1):
+        super().__init__()
+        self.pad_size = pad_size
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        lon_left = x[..., -self.pad_size:]
+        lon_right = x[..., :self.pad_size]
+        lon_padded = torch.cat([lon_left, x, lon_right], dim=-1)
+        lat_zeros = torch.zeros_like(lon_padded[..., -self.pad_size:, :])
+        lat_padded = torch.cat([lat_zeros, lon_padded, lat_zeros], dim=-2)
+        return lat_padded
+
+# transformer module, consitent of possibly multiple attention-modules
+class TransformerNet(nn.Module):
+    def __init__(self, nr_channels, nr_heads):
+        super(TransformerNet, self).__init__()
+
+        value_layer = EnsConv2d(in_channels=nr_channels, out_channels=nr_heads, kernel_size=1, bias=False)
+        
+
+        key_layer = branch_layer(nr_channels=nr_channels,nr_heads=nr_heads)
+        query_layer = branch_layer(nr_channels=nr_channels,nr_heads=nr_heads)
+
+        layer_norm = torch.nn.LayerNorm([nr_channels, 361, 720])
+        value_layer = torch.nn.Sequential(layer_norm, value_layer)
+        key_layer = torch.nn.Sequential(layer_norm, key_layer)
+        query_layer = torch.nn.Sequential(layer_norm, query_layer)
+
+        out_layer = EnsConv2d(in_channels=nr_heads, out_channels=nr_channels, kernel_size=1, padding=0)
+
+        
+        
+
+        transformer_list = []
+        for idx in range(1):
+            curr_transformer = SelfAttentionModule(value_projector=value_layer, key_projector=key_layer, query_projector=query_layer, output_projector=out_layer, activation=nn.ReLU(inplace=True), weight_estimator=SoftmaxWeights(), reweighter=StateReweighter())
+            transformer_list.append(curr_transformer)
+        transformers = torch.nn.Sequential(*transformer_list)
+        self.transformers = transformers
+
+    def forward(self, x):
+        x = self.transformers(x)
+        return x
+
+def branch_layer(nr_channels, nr_heads):
+    return nn.Sequential(
+        EnsConv2d(in_channels=nr_channels, out_channels=nr_heads, kernel_size=1, bias=False),
+        nn.ReLU(inplace=True)
+    )
+
+# single attention module
+class SelfAttentionModule(torch.nn.Module):
+    def __init__(
+            self,
+            value_projector: torch.nn.Module,
+            key_projector: torch.nn.Module,
+            query_projector: torch.nn.Module,
+            output_projector: torch.nn.Module,
+            activation: torch.nn.Module,
+            weight_estimator,
+            reweighter
+     ):
+        super().__init__()
+        self.value_projector = value_projector
+        self.key_projector = key_projector
+        self.query_projector = query_projector
+        self.output_projector = output_projector
+        self.activation = activation
+        self.weight_estimator = weight_estimator
+        self.reweighter = reweighter
+
+    def project_input(
+            self,
+            in_tensor: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        value = self.value_projector(in_tensor)
+        key = self.key_projector(in_tensor)
+        query = self.query_projector(in_tensor)
+        return value, key, query
+
+    def forward(self, in_tensor: torch.Tensor):
+        value, key, query = self.project_input(in_tensor)
+        weights = self.weight_estimator(key, query)
+        transformed_values = self.reweighter(value, weights)
+        output_tensor = self.output_projector(transformed_values)
+        output_tensor += in_tensor
+        activated_tensor = self.activation(output_tensor)
+        return activated_tensor
+
+
+class Reweighter(torch.nn.Module):
+    @staticmethod
+    def _apply_weights(
+            apply_weights_to: torch.Tensor,
+            weight_tensor: torch.Tensor
+    ) -> torch.Tensor:
+        weighted_tensor = torch.einsum(
+            'bcij, bic...->bjc...', weight_tensor, apply_weights_to
+        )
+        return weighted_tensor
+
+    @abc.abstractmethod
+    def forward(
+            self,
+            state_tensor: torch.Tensor,
+            weight_tensor: torch.Tensor
+    ) -> torch.Tensor:
+        pass
+
+
+class StateReweighter(Reweighter):
+    def forward(
+            self,
+            state_tensor: torch.Tensor,
+            weight_tensor: torch.Tensor
+    ) -> torch.Tensor:
+        _, perts_tensor = split_mean_perts(state_tensor, dim=1)
+        weighted_perts = self._apply_weights(perts_tensor, weight_tensor)
+        output_tensor = state_tensor + weighted_perts
+        return output_tensor
+
+class WeightEstimator(torch.nn.Module):
+    @staticmethod
+    def _dot_product(
+            x: torch.Tensor,
+            y: torch.Tensor
+    ) -> torch.Tensor:
+        return torch.einsum('bic..., bjc...->bcij', x, y)
+
+    @staticmethod
+    def _estimate_norm_factor(estimate_from: torch.Tensor) -> float:
+        projection_size = np.prod(estimate_from.shape[3:])
+        norm_factor = 1 / np.sqrt(projection_size)
+        return norm_factor
+
+    @abc.abstractmethod
+    def forward(
+            self,
+            key: torch.Tensor,
+            query: torch.Tensor
+    ) -> torch.Tensor:
+        pass
+
+
+class SoftmaxWeights(WeightEstimator):
+    def forward(
+            self,
+            key: torch.Tensor,
+            query: torch.Tensor
+    ) -> torch.Tensor:
+        gram_mat = self._dot_product(key, query)
+        norm_factor = self._estimate_norm_factor(key)
+        gram_mat = gram_mat * norm_factor
+        weights = torch.softmax(gram_mat, dim=-2)
+        return weights
+
+class EnsConv2d(torch.nn.Module):
+    """
+    Added viewing for ensemble-based 2d convolutions.
+    """
+    def __init__(
+            self, *args, **kwargs
+    ):
+        super().__init__()
+        self.conv2d = EnsembleWrapper(
+            torch.nn.Conv2d(*args, **kwargs)
+        )
+
+    def forward(self, in_tensor: torch.Tensor) -> torch.Tensor:
+        convolved_tensor = self.conv2d(in_tensor)
+        return convolved_tensor
+
+class EnsembleWrapper(torch.nn.Module):
+    def __init__(self, base_layer: torch.nn.Module):
+        super().__init__()
+        self.base_layer = base_layer
+
+    def forward(self, in_tensor: torch.Tensor) -> torch.Tensor:
+        in_tensor_batched = ens_to_batch(in_tensor)
+        modified_tensor = self.base_layer(in_tensor_batched)
+        out_tensor = split_batch_ens(modified_tensor, in_tensor)
+        return out_tensor
+
+def ens_to_batch(in_tensor: torch.Tensor) -> torch.Tensor:
+    try:
+        out_tensor = in_tensor.view(-1, *in_tensor.shape[2:])
+    except RuntimeError:
+        out_tensor = in_tensor.reshape(-1, *in_tensor.shape[2:]).contiguous()
+    return out_tensor
+
+
+def split_batch_ens(
+        in_tensor: torch.Tensor,
+        like_tensor: torch.Tensor
+) -> torch.Tensor:
+    try:
+        out_tensor = in_tensor.view(
+            *like_tensor.shape[:2], *in_tensor.shape[1:]
+        )
+    except RuntimeError:
+        out_tensor = in_tensor.reshape(
+            *like_tensor.shape[:2], *in_tensor.shape[1:]
+        ).contiguous()
+    return out_tensor
+
+
+def split_mean_perts(
+        in_tensor: torch.Tensor,
+        dim: int = 1
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    mean_tensor = in_tensor.mean(dim=dim, keepdims=True)
+    perts_tensor = in_tensor - mean_tensor
+    return mean_tensor, perts_tensor
+
+# for debugging
+if __name__ == '__main__':
+    #loss = crps_loss
+    input = torch.randn(1, 5, 105, 361, 720, requires_grad=True)
+    mean = torch.randn(1, 1, 361, 720, requires_grad=True)
+    stddev = torch.randn(1, 1, 361, 720, requires_grad=True)
+    target = torch.randn(1, 1, 361, 720)
+    #loss = loss(mean, stddev, target)
+    #print(loss)
+    model = transformer([8,8,8], 16, 11, 105)
+    output = model(input)
+    print(output.shape)

--- a/baselines/models/tformer.py
+++ b/baselines/models/tformer.py
@@ -57,6 +57,7 @@ class transformer(nn.Module):
         output_tensor = self.output_layer(transformed_tensor).squeeze(dim=-3)
         output_mean, output_std = estimate_mean_std(output_tensor)
         output_tensor = torch.cat((torch.movedim(output_mean, 0, -1), torch.movedim(output_std, 0,-1)), dim=-1)
+        output_tensor = torch.reshape(output_tensor, (inp.shape[0], inp.shape[-2]*inp.shape[-1],2))
         return output_tensor
 
 def Tformer_prepare(args):

--- a/baselines/utils/parser.py
+++ b/baselines/utils/parser.py
@@ -15,7 +15,7 @@ def args_parser():
                      help='Torch Seed (default: 16)')
 
     parser.add_argument('--model', type=str, default='UNet',
-                     choices=['UNet', 'MLP', 'EMOS'],
+                     choices=['UNet', 'MLP', 'EMOS', 'Tformer', 'LeNet'],
                      help='Model Architecture (default: UNet)')
 
     parser.add_argument('--ens-num', type=int, default=10,


### PR DESCRIPTION
This pull request adds support to run the Tformer and LeNet baselines shown in the paper
+ It adds two new arguments for the model flag in the parser (Tformer, LeNet)
+ adds two new files in baselines/models/ (tformer.py, LeNet.py) which contain the respective models
+ adds two new Datasets to the loader.py (each with the necessary elif case for instantiating the loader)
+ modified Train.py file for special cases when Tformer (estimate mean/stddev from ensemble members) and Tformer or LeNet (reshape the efi_tensor)

I did a test run for the Tformer & LeNet models running each run for 1 training & 1 testing epoch.